### PR TITLE
Fixes Array#indexOf

### DIFF
--- a/mibbu.js
+++ b/mibbu.js
@@ -32,20 +32,32 @@ var mibbu = function(Cwidth, Cheight, _parent){
     /**
      * Older browser's fixes
      */
-    //IE fix Array.indexOf
-    //from 
-    //http://michalbe.blogspot.com/2010/04/removing-item-with-given-value-from.html
-    if(!Array.indexOf){
-        Array.prototype.indexOf = function(obj){
-            var i;
-            for(i=0; i<this.length; i++){
-                if(this[i]===obj){
-                    return i;
-                }
-            }
+    // Fallback for Array#indexOf, where the implementation does not support it
+    // natively
+	//  
+	// Follows the algorithm described in ES-262 15.4.4.14
+	//
+    Array.prototype.indexOf = Array.prototype.indexOf
+    || function (value, start) {
+        var key;
+        var obj = Object(this);
+        var len = obj.length >> 0;
+
+		start = +start || 0;
+		if (!len || start >= len){
             return -1;
-        };
-    }
+        }
+		if (start < 0){
+            start = Math.max(0, len - Math.abs(start));
+        }
+
+		for (key = start; key < len; ++key){
+			if (key in obj && obj[key] === value){
+                return key;
+            }
+        }
+		return -1;
+	}
     
     //and custom remove() method
     var rm = function(value, array) {

--- a/mibbu.js
+++ b/mibbu.js
@@ -41,7 +41,7 @@ var mibbu = function(Cwidth, Cheight, _parent){
     || function (value, start) {
         var key;
         var obj = Object(this);
-        var len = obj.length >> 0;
+        var len = obj.length >>> 0;
 
         start = +start || 0;
         if (!len || start >= len){

--- a/mibbu.js
+++ b/mibbu.js
@@ -43,22 +43,22 @@ var mibbu = function(Cwidth, Cheight, _parent){
         var obj = Object(this);
         var len = obj.length >> 0;
 
-		start = +start || 0;
-		if (!len || start >= len){
+        start = +start || 0;
+        if (!len || start >= len){
             return -1;
         }
-		if (start < 0){
+        if (start < 0){
             start = Math.max(0, len - Math.abs(start));
         }
 
-		for (key = start; key < len; ++key){
-			if (key in obj && obj[key] === value){
+        for (key = start; key < len; ++key){
+            if (key in obj && obj[key] === value){
                 return key;
             }
         }
-		return -1;
-	}
-    
+        return -1;
+    }
+
     //and custom remove() method
     var rm = function(value, array) {
         if (array.indexOf(value)!==-1) {


### PR DESCRIPTION
Fixes fallback for Array#indexOf overwriting the native Array#indexOf where it's implemented, and adds conformance with the algorithm described in the specs.

The previous version checked against `Array.indexOf', which is clearly wrong. Properties that propagate through all of the instances of an object are not defined in the constructor, but in the [[Prototype]]. The problem with this is that it overwrote the native Array#indexOf where there already was an implementation for it. And worse yet, the algorithm implemented by the library wasn't even conformant with the ES5 specs.

This patch fixes it by providing both a ES5-compliant implementation for Array#indexOf, and only using the pure JS fallback where there isn't a native method that does that.
